### PR TITLE
MD-3, MD-79, MD-68: add layouts, Hero section, sidebar (cta widget)

### DIFF
--- a/next/assets/home.svg
+++ b/next/assets/home.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.33335 16.6667V11.6667H11.6667V16.6667H15.8334V10H18.3334L10 2.5L1.66669 10H4.16669V16.6667H8.33335Z" />
+</svg>

--- a/next/components/atoms/Breadcrumbs.tsx
+++ b/next/components/atoms/Breadcrumbs.tsx
@@ -91,7 +91,7 @@ const Breadcrumbs = ({ children, className }: BreadcrumbsProps) => {
     <div className={cx('w-full relative', className)}>
       <div>
         {isExpanded || !isCollapsing ? (
-          <div className="flex items-center gap-1 p-4">{breadcrumbedChildren}</div>
+          <div className="flex items-center gap-1 py-6">{breadcrumbedChildren}</div>
         ) : (
           <div className="flex w-full flex-col">
             <div className="flex w-full items-center justify-between">

--- a/next/components/layouts/Layout.tsx
+++ b/next/components/layouts/Layout.tsx
@@ -1,0 +1,67 @@
+import classnames from 'classnames'
+import React, { ReactNode } from 'react'
+
+import { Enum_Page_Layout, NavigationItemFragment, PageEntityFragment } from '../../graphql'
+import SideBar from '../molecules/SideBar'
+import HeroSection from '../sections/HeroSection'
+import PageWrapper from './PageWrapper'
+
+type LayoutProps = {
+  page: PageEntityFragment
+  navigation: NavigationItemFragment[]
+  faqLink: string
+  phoneNumber: string
+  children?: ReactNode
+}
+
+const Layout = ({ page, navigation, faqLink, phoneNumber, children }: LayoutProps) => {
+  return (
+    <PageWrapper
+      navigation={navigation}
+      faqLink={faqLink}
+      phoneNumber={phoneNumber}
+      header={
+        page.attributes?.layout === Enum_Page_Layout.Full ||
+        page.attributes?.layout === Enum_Page_Layout.Sidebar ? (
+          <HeroSection
+            title={page.attributes?.title}
+            description={page.attributes?.description}
+            cta={page.attributes?.ctaButton}
+          />
+        ) : (
+          // Display just breadcrumbs
+          <HeroSection />
+        )
+      }
+    >
+      <div
+        className={classnames({
+          // Grid layout with sidebar
+          'container relative mx-auto grid gap-6 p-4 md:auto-cols-auto md:grid-flow-col md:py-20':
+            page.attributes?.layout === Enum_Page_Layout.Sidebar,
+          // Centered layout
+          'container relative mx-auto p-4 sm:py-12 sm:px-20 md:px-28 lg:px-40':
+            page.attributes?.layout === Enum_Page_Layout.Centered,
+        })}
+      >
+        {/* Centered layout */}
+        {page.attributes?.layout === Enum_Page_Layout.Centered && (
+          <div className="pb-6 sm:pb-10">
+            <h1 className="text-center">{page.attributes?.title}</h1>
+            {page.attributes?.description && (
+              <p className="mt-6 sm:mt-8">{page.attributes?.description}</p>
+            )}
+          </div>
+        )}
+
+        {children}
+
+        {page.attributes?.layout === Enum_Page_Layout.Sidebar && (
+          <SideBar sidebar={page.attributes?.sidebar} />
+        )}
+      </div>{' '}
+    </PageWrapper>
+  )
+}
+
+export default Layout

--- a/next/components/layouts/PageWrapper.tsx
+++ b/next/components/layouts/PageWrapper.tsx
@@ -1,0 +1,33 @@
+import classnames from 'classnames'
+import Head from 'next/head'
+import React, { ReactNode } from 'react'
+
+import { NavigationItemFragment } from '../../graphql'
+import Navigation from '../molecules/Navigation/Navigation'
+
+type PageWrapperProps = {
+  navigation: NavigationItemFragment[]
+  faqLink: string
+  phoneNumber: string
+  header?: ReactNode
+  children?: ReactNode
+}
+
+const PageWrapper = ({ navigation, faqLink, phoneNumber, header, children }: PageWrapperProps) => {
+  return (
+    <>
+      <Head>
+        <title>Next.js + TypeScript</title>
+      </Head>
+
+      <header>
+        <Navigation faqLink={faqLink} phoneNumber={phoneNumber} navigationItems={navigation} />
+        {header}
+      </header>
+      <main className={classnames('bg-background-beige')}>{children}</main>
+      <footer />
+    </>
+  )
+}
+
+export default PageWrapper

--- a/next/components/molecules/Navigation/Navigation.tsx
+++ b/next/components/molecules/Navigation/Navigation.tsx
@@ -12,29 +12,29 @@ import NavigationMenuMobile from './NavigationMenuMobile'
 import NavigationSearch from './NavigationSearch'
 
 type NavigationProps = {
-  phoneNumber?: string
   faqLink?: string
+  phoneNumber?: string
   navigationItems: NavigationItemFragment[]
 }
 
-const Navigation = ({ phoneNumber, faqLink, navigationItems }: NavigationProps) => {
+const Navigation = ({ faqLink, phoneNumber, navigationItems }: NavigationProps) => {
   const [isMobileNavOpen, setMobileNavOpen] = useState(false)
 
   return (
     <div className="bg-primary text-white">
-      <div className="container relative mx-auto flex h-16 items-center justify-between px-4 lg:h-[120px] lg:pb-8">
+      <div className="container relative mx-auto flex h-16 items-center justify-between px-4 sm:h-[120px] sm:pb-8">
         {/* left side of navigation */}
-        <div className="w-[108px] lg:w-[142px]">
+        <MLink className="w-[108px] lg:w-[142px]" href="/" noStyles noArrow>
           <MarianumLogo className="h-full w-full" />
-        </div>
+        </MLink>
         {/* right side of navigation */}
         <div className="flex items-center gap-4 lg:gap-8">
           {/* desktop faq and phone links */}
-          <div className="hidden items-center gap-8 xl:flex">
+          <div className="flex items-center gap-8">
             {faqLink && (
-              <MLink href={faqLink} className="flex items-center gap-2" noStyles>
+              <MLink href={faqLink} className="hidden items-center gap-2 lg:flex" noStyles>
                 <HelpIcon />
-                <span>Často kladené otázky</span>
+                <span className="">Často kladené otázky</span>
               </MLink>
             )}
             {phoneNumber && (
@@ -51,14 +51,13 @@ const Navigation = ({ phoneNumber, faqLink, navigationItems }: NavigationProps) 
             aria-label="navigačné menu"
             onPress={() => setMobileNavOpen(true)}
             variant="primary"
+            className="sm:hidden"
           >
             <MenuIcon width={24} height={24} />
           </IconButton>
         </div>
         {/* desktop navigation menu */}
-        <div className="absolute inset-x-0 -bottom-8 hidden px-4 lg:block ">
-          <NavigationMenuDesktop navigationItems={navigationItems} />
-        </div>
+        <NavigationMenuDesktop navigationItems={navigationItems} />
         {/* mobile navigation menu */}
         <NavigationMenuMobile
           isOpen={isMobileNavOpen}

--- a/next/components/molecules/Navigation/NavigationMenuDesktop.tsx
+++ b/next/components/molecules/Navigation/NavigationMenuDesktop.tsx
@@ -12,7 +12,7 @@ export type NavigationMenuDesktopProps = {
 
 const NavigationMenuDesktop = ({ navigationItems }: NavigationMenuDesktopProps) => {
   return (
-    <div className="grid h-16 grid-cols-4 bg-white text-foreground-heading shadow">
+    <nav className="absolute inset-x-0 -bottom-8 z-10 mx-4 hidden h-16 grid-cols-4 bg-white text-foreground-heading shadow sm:grid">
       {navigationItems.map(({ id, title, items: menuItems, type }, index) => (
         <Menu key={id} items={menuItems?.filter(isDefined)}>
           {({ isOpen }) => (
@@ -20,7 +20,7 @@ const NavigationMenuDesktop = ({ navigationItems }: NavigationMenuDesktopProps) 
               {index !== 0 && <div className="h-8 w-[1px] bg-border" />}
               <div
                 className={cx(
-                  'flex h-full flex-1 items-center justify-center gap-1 font-semibold transition-all group-focus:bg-primary/10',
+                  'flex h-full flex-1 items-center justify-center gap-1 px-4 font-semibold transition-all group-focus:bg-primary/10',
                   { 'bg-primary/10': isOpen },
                 )}
               >
@@ -39,7 +39,7 @@ const NavigationMenuDesktop = ({ navigationItems }: NavigationMenuDesktopProps) 
           )}
         </Menu>
       ))}
-    </div>
+    </nav>
   )
 }
 

--- a/next/components/molecules/Navigation/NavigationMenuMobile.tsx
+++ b/next/components/molecules/Navigation/NavigationMenuMobile.tsx
@@ -131,7 +131,7 @@ const NavigationMenuMobile = ({ items, isOpen, onClose }: NavigationMenuMobilePr
         </div>
 
         {/* body */}
-        <div className="relative">
+        <nav className="relative">
           {/* previous menu list */}
           <motion.div
             className="absolute top-0 h-full w-full"
@@ -169,7 +169,7 @@ const NavigationMenuMobile = ({ items, isOpen, onClose }: NavigationMenuMobilePr
               onOpenItem={openItemHandler}
             />
           </motion.div>
-        </div>
+        </nav>
       </Dialog.Panel>
     </Dialog>
   )

--- a/next/components/molecules/Navigation/NavigationSearch.tsx
+++ b/next/components/molecules/Navigation/NavigationSearch.tsx
@@ -8,7 +8,7 @@ const NavigationSearch = () => {
       <IconButton aria-label="hľadať" variant="primary">
         <SearchIcon width={24} height={24} />
       </IconButton>
-      <div className="hidden w-72 transition-all duration-500 focus-within:w-[540px] md:flex">
+      <div className="hidden w-72 transition-all duration-500 focus-within:w-[540px] sm:flex">
         <Search
           className="w-full border-transparent bg-white/[16%] focus-within:bg-white/100 focus-within:text-foreground hover:border-transparent hover:focus-within:border-border"
           inputClassName="placeholder:text-white focus:placeholder:text-foreground-placeholder"

--- a/next/components/molecules/Section.tsx
+++ b/next/components/molecules/Section.tsx
@@ -1,0 +1,26 @@
+import classnames from 'classnames'
+import React, { ReactNode } from 'react'
+
+type SectionProps = {
+  children: ReactNode
+  fullWidth?: boolean
+  color?: 'default' | 'white'
+}
+
+const Section = ({ children, color = 'default', fullWidth = false }: SectionProps) => {
+  return (
+    <section
+      className={classnames({ 'py-20': fullWidth, 'bg-white': color === 'white' && fullWidth })}
+    >
+      <div
+        className={classnames({
+          'container relative mx-auto px-4': fullWidth,
+        })}
+      >
+        {children}
+      </div>
+    </section>
+  )
+}
+
+export default Section

--- a/next/components/molecules/SideBar.tsx
+++ b/next/components/molecules/SideBar.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+
+import MailIcon from '../../assets/mail.svg'
+import PhoneIcon from '../../assets/phone.svg'
+import { SidebarFragment } from '../../graphql'
+import Button from '../atoms/Button'
+
+type SideBarProps = {
+  sidebar: SidebarFragment | null | undefined
+}
+
+const SideBar = ({ sidebar }: SideBarProps) => {
+  if (!sidebar) {
+    return <aside className="md:w-[360px]" />
+  }
+
+  const { title, text, ctaButton, contact } = sidebar
+  return (
+    <aside className="flex h-fit flex-col bg-white p-6 md:w-[360px]">
+      {title && <h5>{title}</h5>}
+      {text && <p className="mt-2">{text}</p>}
+      {ctaButton ? (
+        <>
+          <Button href={ctaButton.url} variant="primary" className="mt-6">
+            {ctaButton.label}
+          </Button>
+          {contact?.data?.attributes && (
+            <div className="flex flex-col items-center">
+              <div className="mt-4">alebo</div>
+              <Button variant="plain-primary" startIcon={<PhoneIcon />} className="mt-4">
+                {contact.data.attributes.phone1}
+              </Button>
+              <Button variant="plain-primary" startIcon={<MailIcon />} className="mt-2">
+                {contact.data.attributes.email}
+              </Button>
+            </div>
+          )}
+        </>
+      ) : (
+        contact?.data?.attributes && (
+          <>
+            <Button variant="primary" startIcon={<PhoneIcon />} className="mt-6">
+              {contact.data.attributes.phone1}
+            </Button>
+            {contact.data.attributes.phone2 && (
+              <Button variant="tertiary" startIcon={<PhoneIcon />} className="mt-3">
+                {contact.data.attributes.phone2}
+              </Button>
+            )}
+            <div className="flex flex-col items-center">
+              <div className="mt-4">alebo nas kontaktujte emailom</div>
+              <Button variant="plain-primary" startIcon={<MailIcon />} className="mt-4">
+                {contact.data.attributes.email}
+              </Button>
+            </div>
+          </>
+        )
+      )}
+    </aside>
+  )
+}
+
+export default SideBar

--- a/next/components/sections/HeroSection.tsx
+++ b/next/components/sections/HeroSection.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import HomeIcon from '../../assets/home.svg'
+import { CtaButtonFragment } from '../../graphql'
+import Breadcrumbs from '../atoms/Breadcrumbs'
+import Button from '../atoms/Button'
+import MLink from '../atoms/MLink'
+
+type HeroSectionProps = {
+  title?: string | null | undefined
+  description?: string | null | undefined
+  cta?: CtaButtonFragment | null | undefined
+}
+
+const HeroSection = ({ title, description, cta }: HeroSectionProps) => {
+  return (
+    <div className="bg-primary-dark text-white/72">
+      <div className="container relative mx-auto px-4">
+        <Breadcrumbs className="md:pt-8">
+          {[
+            {
+              label: <HomeIcon />,
+              link: '#home',
+            },
+            {
+              label: 'very',
+              link: '#very',
+            },
+          ].map(({ label, link }) => (
+            <MLink key={link} href={link} noStyles className="underline">
+              {label}
+            </MLink>
+          ))}
+        </Breadcrumbs>
+        <div className="py-5 text-white empty:hidden md:w-[648px] md:pb-14 md:pt-6">
+          {title && <h1>{title}</h1>}
+          {description && <p className="mt-3 text-white opacity-72">{description}</p>}
+          {cta && (
+            <Button href={cta.url} className="mt-6">
+              {cta.label}
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default HeroSection

--- a/next/graphql/index.ts
+++ b/next/graphql/index.ts
@@ -231,6 +231,33 @@ export type ComponentBlocksPriceListItemFiltersInput = {
   price?: InputMaybe<FloatFilterInput>;
 };
 
+export type ComponentBlocksSidebar = {
+  __typename?: 'ComponentBlocksSidebar';
+  contact?: Maybe<ContactEntityResponse>;
+  ctaButton?: Maybe<ComponentBlocksButtonLink>;
+  id: Scalars['ID'];
+  text?: Maybe<Scalars['String']>;
+  title?: Maybe<Scalars['String']>;
+};
+
+export type ComponentBlocksSidebarFiltersInput = {
+  and?: InputMaybe<Array<InputMaybe<ComponentBlocksSidebarFiltersInput>>>;
+  contact?: InputMaybe<ContactFiltersInput>;
+  ctaButton?: InputMaybe<ComponentBlocksButtonLinkFiltersInput>;
+  not?: InputMaybe<ComponentBlocksSidebarFiltersInput>;
+  or?: InputMaybe<Array<InputMaybe<ComponentBlocksSidebarFiltersInput>>>;
+  text?: InputMaybe<StringFilterInput>;
+  title?: InputMaybe<StringFilterInput>;
+};
+
+export type ComponentBlocksSidebarInput = {
+  contact?: InputMaybe<Scalars['ID']>;
+  ctaButton?: InputMaybe<ComponentBlocksButtonLinkInput>;
+  id?: InputMaybe<Scalars['ID']>;
+  text?: InputMaybe<Scalars['String']>;
+  title?: InputMaybe<Scalars['String']>;
+};
+
 export type ComponentBlocksSidepanel = {
   __typename?: 'ComponentBlocksSidepanel';
   id: Scalars['ID'];
@@ -250,15 +277,15 @@ export type ComponentGeneralContacts = {
 
 export type ComponentGeneralHeader = {
   __typename?: 'ComponentGeneralHeader';
-  faqsLink?: Maybe<Scalars['String']>;
+  faqLink?: Maybe<Scalars['String']>;
   id: Scalars['ID'];
-  phone?: Maybe<Scalars['String']>;
+  phoneNumber?: Maybe<Scalars['String']>;
 };
 
 export type ComponentGeneralHeaderInput = {
-  faqsLink?: InputMaybe<Scalars['String']>;
+  faqLink?: InputMaybe<Scalars['String']>;
   id?: InputMaybe<Scalars['ID']>;
-  phone?: InputMaybe<Scalars['String']>;
+  phoneNumber?: InputMaybe<Scalars['String']>;
 };
 
 export type ComponentGeneralSocial = {
@@ -385,8 +412,8 @@ export type Contact = {
   locale?: Maybe<Scalars['String']>;
   localizations?: Maybe<ContactRelationResponseCollection>;
   name?: Maybe<Scalars['String']>;
-  phone?: Maybe<Scalars['String']>;
-  phoneSecondary?: Maybe<Scalars['String']>;
+  phone1?: Maybe<Scalars['String']>;
+  phone2?: Maybe<Scalars['String']>;
   title: Scalars['String'];
   updatedAt?: Maybe<Scalars['DateTime']>;
 };
@@ -425,8 +452,8 @@ export type ContactFiltersInput = {
   name?: InputMaybe<StringFilterInput>;
   not?: InputMaybe<ContactFiltersInput>;
   or?: InputMaybe<Array<InputMaybe<ContactFiltersInput>>>;
-  phone?: InputMaybe<StringFilterInput>;
-  phoneSecondary?: InputMaybe<StringFilterInput>;
+  phone1?: InputMaybe<StringFilterInput>;
+  phone2?: InputMaybe<StringFilterInput>;
   title?: InputMaybe<StringFilterInput>;
   updatedAt?: InputMaybe<DateTimeFilterInput>;
 };
@@ -434,8 +461,8 @@ export type ContactFiltersInput = {
 export type ContactInput = {
   email?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
-  phone?: InputMaybe<Scalars['String']>;
-  phoneSecondary?: InputMaybe<Scalars['String']>;
+  phone1?: InputMaybe<Scalars['String']>;
+  phone2?: InputMaybe<Scalars['String']>;
   title?: InputMaybe<Scalars['String']>;
 };
 
@@ -524,6 +551,13 @@ export enum Enum_Componentsectionslistingsection_Type {
   Services = 'services'
 }
 
+export enum Enum_Page_Layout {
+  Centered = 'centered',
+  CenteredWithImage = 'centeredWithImage',
+  Full = 'full',
+  Sidebar = 'sidebar'
+}
+
 export type Error = {
   __typename?: 'Error';
   code: Scalars['String'];
@@ -591,7 +625,7 @@ export type GeneralRelationResponseCollection = {
   data: Array<GeneralEntity>;
 };
 
-export type GenericMorph = Branch | ComponentBlocksAccordionItem | ComponentBlocksBranchItem | ComponentBlocksButtonLink | ComponentBlocksContactItem | ComponentBlocksCta | ComponentBlocksDocumentItem | ComponentBlocksPriceListItem | ComponentBlocksSidepanel | ComponentGeneralContacts | ComponentGeneralHeader | ComponentGeneralSocial | ComponentSectionsAccordionGroup | ComponentSectionsBranchGroup | ComponentSectionsContactGroup | ComponentSectionsDocumentGroup | ComponentSectionsGallery | ComponentSectionsListingSection | ComponentSectionsPriceList | ComponentSectionsRichtext | Contact | Document | General | HomePage | I18NLocale | Page | Partner | Tmp | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser;
+export type GenericMorph = Branch | ComponentBlocksAccordionItem | ComponentBlocksBranchItem | ComponentBlocksButtonLink | ComponentBlocksContactItem | ComponentBlocksCta | ComponentBlocksDocumentItem | ComponentBlocksPriceListItem | ComponentBlocksSidebar | ComponentBlocksSidepanel | ComponentGeneralContacts | ComponentGeneralHeader | ComponentGeneralSocial | ComponentSectionsAccordionGroup | ComponentSectionsBranchGroup | ComponentSectionsContactGroup | ComponentSectionsDocumentGroup | ComponentSectionsGallery | ComponentSectionsListingSection | ComponentSectionsPriceList | ComponentSectionsRichtext | Contact | Document | General | HomePage | I18NLocale | Page | Partner | Tmp | UploadFile | UploadFolder | UsersPermissionsPermission | UsersPermissionsRole | UsersPermissionsUser;
 
 export type HomePage = {
   __typename?: 'HomePage';
@@ -1125,10 +1159,14 @@ export enum NavigationRenderType {
 export type Page = {
   __typename?: 'Page';
   createdAt?: Maybe<Scalars['DateTime']>;
+  ctaButton?: Maybe<ComponentBlocksButtonLink>;
+  description?: Maybe<Scalars['String']>;
+  layout: Enum_Page_Layout;
   locale?: Maybe<Scalars['String']>;
   localizations?: Maybe<PageRelationResponseCollection>;
   publishedAt?: Maybe<Scalars['DateTime']>;
   sections?: Maybe<Array<Maybe<PageSectionsDynamicZone>>>;
+  sidebar?: Maybe<ComponentBlocksSidebar>;
   slug: Scalars['String'];
   title: Scalars['String'];
   updatedAt?: Maybe<Scalars['DateTime']>;
@@ -1162,20 +1200,28 @@ export type PageEntityResponseCollection = {
 export type PageFiltersInput = {
   and?: InputMaybe<Array<InputMaybe<PageFiltersInput>>>;
   createdAt?: InputMaybe<DateTimeFilterInput>;
+  ctaButton?: InputMaybe<ComponentBlocksButtonLinkFiltersInput>;
+  description?: InputMaybe<StringFilterInput>;
   id?: InputMaybe<IdFilterInput>;
+  layout?: InputMaybe<StringFilterInput>;
   locale?: InputMaybe<StringFilterInput>;
   localizations?: InputMaybe<PageFiltersInput>;
   not?: InputMaybe<PageFiltersInput>;
   or?: InputMaybe<Array<InputMaybe<PageFiltersInput>>>;
   publishedAt?: InputMaybe<DateTimeFilterInput>;
+  sidebar?: InputMaybe<ComponentBlocksSidebarFiltersInput>;
   slug?: InputMaybe<StringFilterInput>;
   title?: InputMaybe<StringFilterInput>;
   updatedAt?: InputMaybe<DateTimeFilterInput>;
 };
 
 export type PageInput = {
+  ctaButton?: InputMaybe<ComponentBlocksButtonLinkInput>;
+  description?: InputMaybe<Scalars['String']>;
+  layout?: InputMaybe<Enum_Page_Layout>;
   publishedAt?: InputMaybe<Scalars['DateTime']>;
   sections?: InputMaybe<Array<Scalars['PageSectionsDynamicZoneInput']>>;
+  sidebar?: InputMaybe<ComponentBlocksSidebarInput>;
   slug?: InputMaybe<Scalars['String']>;
   title?: InputMaybe<Scalars['String']>;
 };
@@ -1900,7 +1946,13 @@ export type UsersPermissionsUserRelationResponseCollection = {
 
 export type NavigationItemFragment = { __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null, items?: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null, items?: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null } | null> | null } | null> | null };
 
-export type PageEntityFragment = { __typename?: 'PageEntity', id?: string | null, attributes?: { __typename?: 'Page', title: string, slug: string } | null };
+export type CtaButtonFragment = { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null };
+
+export type SidebarFragment = { __typename?: 'ComponentBlocksSidebar', title?: string | null, text?: string | null, ctaButton?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null, contact?: { __typename?: 'ContactEntityResponse', data?: { __typename?: 'ContactEntity', id?: string | null, attributes?: { __typename?: 'Contact', title: string, name?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null };
+
+export type ContactEntityFragment = { __typename?: 'ContactEntity', id?: string | null, attributes?: { __typename?: 'Contact', title: string, name?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null };
+
+export type PageEntityFragment = { __typename?: 'PageEntity', id?: string | null, attributes?: { __typename?: 'Page', title: string, slug: string, publishedAt?: any | null, layout: Enum_Page_Layout, description?: string | null, ctaButton?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null, sidebar?: { __typename?: 'ComponentBlocksSidebar', title?: string | null, text?: string | null, ctaButton?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null, contact?: { __typename?: 'ContactEntityResponse', data?: { __typename?: 'ContactEntity', id?: string | null, attributes?: { __typename?: 'Contact', title: string, name?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null } | null, sections?: Array<{ __typename: 'ComponentSectionsAccordionGroup', id: string, title?: string | null, accordions?: Array<{ __typename?: 'ComponentBlocksAccordionItem', id: string, title?: string | null, description?: string | null } | null> | null } | { __typename?: 'ComponentSectionsBranchGroup' } | { __typename?: 'ComponentSectionsContactGroup' } | { __typename?: 'ComponentSectionsDocumentGroup' } | { __typename?: 'ComponentSectionsGallery' } | { __typename?: 'ComponentSectionsPriceList' } | { __typename: 'ComponentSectionsRichtext', id: string, markdown?: string | null, button?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null } | { __typename?: 'Error' } | null> | null } | null };
 
 export type MeQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -1912,7 +1964,7 @@ export type NavigationQueryVariables = Exact<{
 }>;
 
 
-export type NavigationQuery = { __typename?: 'Query', navigation: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null, items?: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null, items?: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null } | null> | null } | null> | null } | null> };
+export type NavigationQuery = { __typename?: 'Query', navigation: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null, items?: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null, items?: Array<{ __typename?: 'NavigationItem', id: number, title: string, path?: string | null, type: string, related?: { __typename?: 'NavigationItemRelatedData', id: number, attributes?: { __typename: 'Branch', title: string, slug: string } | { __typename: 'Page', title: string, slug: string } | { __typename: 'Tmp' } | null } | null } | null> | null } | null> | null } | null>, general?: { __typename?: 'GeneralEntityResponse', data?: { __typename?: 'GeneralEntity', attributes?: { __typename?: 'General', header?: { __typename?: 'ComponentGeneralHeader', faqLink?: string | null, phoneNumber?: string | null } | null } | null } | null } | null };
 
 export type PageBySlugQueryVariables = Exact<{
   locale: Scalars['I18NLocaleCode'];
@@ -1920,7 +1972,7 @@ export type PageBySlugQueryVariables = Exact<{
 }>;
 
 
-export type PageBySlugQuery = { __typename?: 'Query', pages?: { __typename?: 'PageEntityResponseCollection', data: Array<{ __typename?: 'PageEntity', id?: string | null, attributes?: { __typename?: 'Page', title: string, slug: string } | null }> } | null };
+export type PageBySlugQuery = { __typename?: 'Query', pages?: { __typename?: 'PageEntityResponseCollection', data: Array<{ __typename?: 'PageEntity', id?: string | null, attributes?: { __typename?: 'Page', title: string, slug: string, publishedAt?: any | null, layout: Enum_Page_Layout, description?: string | null, ctaButton?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null, sidebar?: { __typename?: 'ComponentBlocksSidebar', title?: string | null, text?: string | null, ctaButton?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null, contact?: { __typename?: 'ContactEntityResponse', data?: { __typename?: 'ContactEntity', id?: string | null, attributes?: { __typename?: 'Contact', title: string, name?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null } | null, sections?: Array<{ __typename: 'ComponentSectionsAccordionGroup', id: string, title?: string | null, accordions?: Array<{ __typename?: 'ComponentBlocksAccordionItem', id: string, title?: string | null, description?: string | null } | null> | null } | { __typename?: 'ComponentSectionsBranchGroup' } | { __typename?: 'ComponentSectionsContactGroup' } | { __typename?: 'ComponentSectionsDocumentGroup' } | { __typename?: 'ComponentSectionsGallery' } | { __typename?: 'ComponentSectionsPriceList' } | { __typename: 'ComponentSectionsRichtext', id: string, markdown?: string | null, button?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null } | { __typename?: 'Error' } | null> | null } | null }> } | null };
 
 export type PagesStaticPathsQueryVariables = Exact<{
   locale?: InputMaybe<Scalars['I18NLocaleCode']>;
@@ -1932,7 +1984,7 @@ export type PagesStaticPathsQuery = { __typename?: 'Query', pages?: { __typename
 export type PagesQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type PagesQuery = { __typename?: 'Query', pages?: { __typename?: 'PageEntityResponseCollection', data: Array<{ __typename?: 'PageEntity', id?: string | null, attributes?: { __typename?: 'Page', title: string, slug: string, publishedAt?: any | null, sections?: Array<{ __typename: 'ComponentSectionsAccordionGroup', id: string, title?: string | null, accordions?: Array<{ __typename?: 'ComponentBlocksAccordionItem', id: string, title?: string | null, description?: string | null } | null> | null } | { __typename?: 'ComponentSectionsBranchGroup' } | { __typename?: 'ComponentSectionsContactGroup' } | { __typename?: 'ComponentSectionsDocumentGroup' } | { __typename?: 'ComponentSectionsGallery' } | { __typename?: 'ComponentSectionsPriceList' } | { __typename?: 'ComponentSectionsRichtext', markdown?: string | null, button?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null } | { __typename?: 'Error' } | null> | null } | null }> } | null };
+export type PagesQuery = { __typename?: 'Query', pages?: { __typename?: 'PageEntityResponseCollection', data: Array<{ __typename?: 'PageEntity', id?: string | null, attributes?: { __typename?: 'Page', title: string, slug: string, publishedAt?: any | null, layout: Enum_Page_Layout, description?: string | null, ctaButton?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null, sidebar?: { __typename?: 'ComponentBlocksSidebar', title?: string | null, text?: string | null, ctaButton?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null, contact?: { __typename?: 'ContactEntityResponse', data?: { __typename?: 'ContactEntity', id?: string | null, attributes?: { __typename?: 'Contact', title: string, name?: string | null, email?: string | null, phone1?: string | null, phone2?: string | null } | null } | null } | null } | null, sections?: Array<{ __typename: 'ComponentSectionsAccordionGroup', id: string, title?: string | null, accordions?: Array<{ __typename?: 'ComponentBlocksAccordionItem', id: string, title?: string | null, description?: string | null } | null> | null } | { __typename?: 'ComponentSectionsBranchGroup' } | { __typename?: 'ComponentSectionsContactGroup' } | { __typename?: 'ComponentSectionsDocumentGroup' } | { __typename?: 'ComponentSectionsGallery' } | { __typename?: 'ComponentSectionsPriceList' } | { __typename: 'ComponentSectionsRichtext', id: string, markdown?: string | null, button?: { __typename?: 'ComponentBlocksButtonLink', label: string, url: string, targetBlank?: boolean | null } | null } | { __typename?: 'Error' } | null> | null } | null }> } | null };
 
 export const NavigationItemFragmentDoc = gql`
     fragment NavigationItem on NavigationItem {
@@ -1996,15 +2048,81 @@ export const NavigationItemFragmentDoc = gql`
   }
 }
     `;
+export const CtaButtonFragmentDoc = gql`
+    fragment CtaButton on ComponentBlocksButtonLink {
+  label
+  url
+  targetBlank
+}
+    `;
+export const ContactEntityFragmentDoc = gql`
+    fragment ContactEntity on ContactEntity {
+  id
+  attributes {
+    title
+    name
+    email
+    phone1
+    phone2
+  }
+}
+    `;
+export const SidebarFragmentDoc = gql`
+    fragment Sidebar on ComponentBlocksSidebar {
+  title
+  text
+  ctaButton {
+    ...CtaButton
+  }
+  contact {
+    data {
+      ...ContactEntity
+    }
+  }
+}
+    ${CtaButtonFragmentDoc}
+${ContactEntityFragmentDoc}`;
 export const PageEntityFragmentDoc = gql`
     fragment PageEntity on PageEntity {
   id
   attributes {
     title
     slug
+    publishedAt
+    layout
+    description
+    ctaButton {
+      ...CtaButton
+    }
+    sidebar {
+      ...Sidebar
+    }
+    sections {
+      ... on ComponentSectionsAccordionGroup {
+        __typename
+        id
+        title
+        accordions {
+          id
+          title
+          description
+        }
+      }
+      ... on ComponentSectionsRichtext {
+        __typename
+        id
+        markdown
+        button {
+          label
+          url
+          targetBlank
+        }
+      }
+    }
   }
 }
-    `;
+    ${CtaButtonFragmentDoc}
+${SidebarFragmentDoc}`;
 export const MeDocument = gql`
     query Me {
   me {
@@ -2021,6 +2139,16 @@ export const NavigationDocument = gql`
     locale: $locale
   ) {
     ...NavigationItem
+  }
+  general(locale: $locale) {
+    data {
+      attributes {
+        header {
+          faqLink
+          phoneNumber
+        }
+      }
+    }
   }
 }
     ${NavigationItemFragmentDoc}`;
@@ -2050,36 +2178,11 @@ export const PagesDocument = gql`
     query Pages {
   pages(locale: "sk") {
     data {
-      id
-      attributes {
-        title
-        slug
-        publishedAt
-        sections {
-          ... on ComponentSectionsAccordionGroup {
-            __typename
-            id
-            title
-            accordions {
-              id
-              title
-              description
-            }
-          }
-          ... on ComponentSectionsRichtext {
-            markdown
-            button {
-              label
-              url
-              targetBlank
-            }
-          }
-        }
-      }
+      ...PageEntity
     }
   }
 }
-    `;
+    ${PageEntityFragmentDoc}`;
 
 export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string) => Promise<T>;
 

--- a/next/graphql/queries/fragments.gql
+++ b/next/graphql/queries/fragments.gql
@@ -64,10 +64,71 @@ fragment NavigationItem on NavigationItem {
   }
 }
 
+fragment CtaButton on ComponentBlocksButtonLink {
+  label
+  url
+  targetBlank
+}
+
+fragment Sidebar on ComponentBlocksSidebar {
+  title
+  text
+  ctaButton {
+    ...CtaButton
+  }
+  contact {
+    data {
+      ...ContactEntity
+    }
+  }
+}
+
+fragment ContactEntity on ContactEntity {
+  id
+  attributes {
+    title
+    name
+    email
+    phone1
+    phone2
+  }
+}
+
 fragment PageEntity on PageEntity {
   id
   attributes {
     title
     slug
+    publishedAt
+    layout
+    description
+    ctaButton {
+      ...CtaButton
+    }
+    sidebar {
+      ...Sidebar
+    }
+    sections {
+      ... on ComponentSectionsAccordionGroup {
+        __typename
+        id
+        title
+        accordions {
+          id
+          title
+          description
+        }
+      }
+      ... on ComponentSectionsRichtext {
+        __typename
+        id
+        markdown
+        button {
+          label
+          url
+          targetBlank
+        }
+      }
+    }
   }
 }

--- a/next/graphql/queries/queries.gql
+++ b/next/graphql/queries/queries.gql
@@ -14,6 +14,16 @@ query Navigation($locale: I18NLocaleCode!) {
   ) {
     ...NavigationItem
   }
+  general(locale: $locale) {
+    data {
+      attributes {
+        header {
+          faqLink
+          phoneNumber
+        }
+      }
+    }
+  }
 }
 
 query PageBySlug($locale: I18NLocaleCode!, $slug: String!) {
@@ -41,32 +51,7 @@ query PagesStaticPaths($locale: I18NLocaleCode) {
 query Pages {
   pages(locale: "sk") {
     data {
-      id
-      attributes {
-        title
-        slug
-        publishedAt
-        sections {
-          ... on ComponentSectionsAccordionGroup {
-            __typename
-            id
-            title
-            accordions {
-              id
-              title
-              description
-            }
-          }
-          ... on ComponentSectionsRichtext {
-            markdown
-            button {
-              label
-              url
-              targetBlank
-            }
-          }
-        }
-      }
+      ...PageEntity
     }
   }
 }

--- a/next/pages/index.tsx
+++ b/next/pages/index.tsx
@@ -2,32 +2,28 @@ import { GetStaticProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 
-import Navigation from '../components/molecules/Navigation/Navigation'
-import SectionExample from '../components/sections/SectionExample'
+import PageWrapper from '../components/layouts/PageWrapper'
 import { NavigationItemFragment } from '../graphql'
 import { client } from '../utils/gql'
 
 type HomeProps = {
   navigation: NavigationItemFragment[]
+  faqLink: string
+  phoneNumber: string
 }
 
-const Home = ({ navigation }: HomeProps) => {
+const Home = ({ navigation, faqLink, phoneNumber }: HomeProps) => {
   const { t } = useTranslation()
 
   return (
-    <div className="bg-background-beige">
-      <Navigation phoneNumber="+421 987 654 321" faqLink="/faq" navigationItems={navigation} />
-      <div className="h-96" />
-      <div>{t('general.hello')}</div>
-      <div className="h-96" />
-      <SectionExample />
-      <div className="h-96" />
-    </div>
+    <PageWrapper navigation={navigation} faqLink={faqLink} phoneNumber={phoneNumber}>
+      {t('general.hello')}
+    </PageWrapper>
   )
 }
 
 export const getStaticProps: GetStaticProps<HomeProps> = async ({ locale = 'sk' }) => {
-  const [{ navigation }, translations] = await Promise.all([
+  const [{ navigation, general }, translations] = await Promise.all([
     client.Navigation({ locale }),
     serverSideTranslations(locale, ['common']) as any,
   ])
@@ -35,6 +31,8 @@ export const getStaticProps: GetStaticProps<HomeProps> = async ({ locale = 'sk' 
   return {
     props: {
       navigation,
+      faqLink: general?.data?.attributes?.header?.faqLink ?? '',
+      phoneNumber: general?.data?.attributes?.header?.phoneNumber ?? '',
       ...translations,
     },
     revalidate: 10,

--- a/strapi/src/api/contact/content-types/contact/schema.json
+++ b/strapi/src/api/contact/content-types/contact/schema.json
@@ -33,14 +33,6 @@
       },
       "type": "string"
     },
-    "phone": {
-      "pluginOptions": {
-        "i18n": {
-          "localized": false
-        }
-      },
-      "type": "string"
-    },
     "email": {
       "pluginOptions": {
         "i18n": {
@@ -49,7 +41,15 @@
       },
       "type": "string"
     },
-    "phoneSecondary": {
+    "phone1": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "string"
+    },
+    "phone2": {
       "pluginOptions": {
         "i18n": {
           "localized": true

--- a/strapi/src/api/page/content-types/page/schema.json
+++ b/strapi/src/api/page/content-types/page/schema.json
@@ -35,6 +35,39 @@
       "targetField": "title",
       "required": true
     },
+    "layout": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      },
+      "type": "enumeration",
+      "enum": [
+        "full",
+        "sidebar",
+        "centered"
+      ],
+      "default": "full",
+      "required": true
+    },
+    "description": {
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "type": "text"
+    },
+    "ctaButton": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "blocks.button-link"
+    },
     "sections": {
       "pluginOptions": {
         "i18n": {
@@ -51,6 +84,16 @@
         "sections.document-group",
         "sections.price-list"
       ]
+    },
+    "sidebar": {
+      "type": "component",
+      "repeatable": false,
+      "pluginOptions": {
+        "i18n": {
+          "localized": true
+        }
+      },
+      "component": "blocks.sidebar"
     }
   }
 }

--- a/strapi/src/components/blocks/sidebar.json
+++ b/strapi/src/components/blocks/sidebar.json
@@ -1,0 +1,26 @@
+{
+  "collectionName": "components_blocks_sidebars",
+  "info": {
+    "displayName": "sidebar",
+    "icon": "align-right"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "text"
+    },
+    "text": {
+      "type": "text"
+    },
+    "ctaButton": {
+      "type": "component",
+      "repeatable": false,
+      "component": "blocks.button-link"
+    },
+    "contact": {
+      "type": "relation",
+      "relation": "oneToOne",
+      "target": "api::contact.contact"
+    }
+  }
+}

--- a/strapi/src/components/general/header.json
+++ b/strapi/src/components/general/header.json
@@ -7,10 +7,10 @@
   },
   "options": {},
   "attributes": {
-    "faqsLink": {
+    "faqLink": {
       "type": "string"
     },
-    "phone": {
+    "phoneNumber": {
       "type": "string"
     }
   }


### PR DESCRIPTION
- add `PageWrapper` component - it takes care of displaying header and footer
- add `Layout` component - it takes care of displaying proper layout based on strapi `layout` field
- add `Sidebar` component (aka CTA Widget)
- add Hero section
- update queries and fragments
- update styles
  - show desktop navigation from `sm:` instead of `lg:` - it may need some more attention


Note:
- breadcrubs are not dynamic yet, there is just static example
- Head is just static example