### PR TITLE
Remove meilisearch-secret from strapi deployment

### DIFF
--- a/strapi/kubernetes/base/deployment.yml
+++ b/strapi/kubernetes/base/deployment.yml
@@ -36,8 +36,6 @@ spec:
             - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-database-secret
             - secretRef:
-                name: ${BUILD_REPOSITORY_NAME}-meilisearch-secret
-            - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-cloudflare-turnstile-secret
             - secretRef:
                 name: ${BUILD_REPOSITORY_NAME}-mailgun-secret


### PR DESCRIPTION
meilisearch-secret should only be mounted in stateful-set-meilisearch.yml (the Meilisearch pod itself). It was incorrectly added to deployment.yml (the Strapi app pod).